### PR TITLE
Extended OpenSSL Metrics Parser 

### DIFF
--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/Examples/OpenSSL/OpenSSL-speed-multi-ecdhx448.txt
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/Examples/OpenSSL/OpenSSL-speed-multi-ecdhx448.txt
@@ -1,0 +1,39 @@
+Forked child 0
+Forked child 1
+Forked child 2
+Forked child 3
+Forked child 4
+Forked child 5
+Forked child 6
+Forked child 7
+Forked child 8
+Forked child 9
+Forked child 10
+Forked child 11
+Forked child 12
+Forked child 13
+Forked child 14
+Forked child 15
+Got: +F5:23:448:2680.184985:0.000373 from 0
+Got: +F5:23:448:2676.941667:0.000374 from 1
+Got: +F5:23:448:2686.491667:0.000372 from 2
+Got: +F5:23:448:2679.958333:0.000373 from 3
+Got: +F5:23:448:2682.000000:0.000373 from 4
+Got: +F5:23:448:2678.875000:0.000373 from 5
+Got: +F5:23:448:2679.758333:0.000373 from 6
+Got: +F5:23:448:2686.466667:0.000372 from 7
+Got: +F5:23:448:2676.683333:0.000374 from 8
+Got: +F5:23:448:2681.883333:0.000373 from 9
+Got: +F5:23:448:2678.241667:0.000373 from 10
+Got: +F5:23:448:2676.475000:0.000374 from 11
+Got: +F5:23:448:2687.133333:0.000372 from 12
+Got: +F5:23:448:2677.341667:0.000374 from 13
+Got: +F5:23:448:2683.133333:0.000373 from 14
+Got: +F5:23:448:2684.383333:0.000373 from 15
+version: 3.0.0-beta3-dev
+built on: built on: Thu Aug  5 18:45:56 2021 UTC
+options:bn(64,64)
+compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -Wall -O3 -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL -DNDEBUG
+CPUINFO: OPENSSL_ia32cap=0xfffa32235f8bffff:0x415f46f1bf2fbb
+                          op      op/s
+448 bits ecdh (X448)   0.0000s  42896.0

--- a/src/VirtualClient/VirtualClient.Actions.UnitTests/OpenSSL/OpenSslMetricsParserTests.cs
+++ b/src/VirtualClient/VirtualClient.Actions.UnitTests/OpenSSL/OpenSslMetricsParserTests.cs
@@ -223,6 +223,32 @@ namespace VirtualClient.Actions
         }
 
         [Test]
+        public void OpenSslParserParsesResultsCorrectly_ecdhx448_Scenario()
+        {
+            /* In this scenario, we are evaluating a single cipher as well as all byte buffer sizes.
+             
+               Example:
+                                           op      op/s
+                 448 bits ecdh (X448)   0.0000s  42896.0
+             */
+
+            OpenSslMetricsParser parser = new OpenSslMetricsParser(
+                File.ReadAllText(Path.Combine(OpenSslMetricsParserTests.examplesDir, "OpenSSL-speed-multi-ecdhx448.txt")),
+                "speed -multi 16 -seconds 5 ecdhx448");
+
+            IEnumerable<Metric> metrics = parser.Parse();
+
+            Assert.IsNotNull(metrics);
+            Assert.AreEqual(2, metrics.Count());
+
+            OpenSslMetricsParserTests.AssertMetricsMatch("448 bits ecdh (X448)", metrics, new Dictionary<string, double>
+            {
+                { "448 bits ecdh (X448) op", 0 },
+                { "448 bits ecdh (X448) op/s", 42896.0 },
+            });
+        }
+
+        [Test]
         public void OpenSslParserParsesResultsCorrectly_AllCiphers_Scenario()
         {
             /* In this scenario, we are evaluating all ciphers as well as all byte buffer sizes.

--- a/src/VirtualClient/VirtualClient.Actions/OpenSSL/OpenSslMetricsParser.cs
+++ b/src/VirtualClient/VirtualClient.Actions/OpenSSL/OpenSslMetricsParser.cs
@@ -290,7 +290,21 @@ namespace VirtualClient.Actions
             // Example:
             //                    sign verify    sign/s verify/s
             //  rsa 2048 bits 0.000820s 0.000024s   1219.7  41003.9
+
+            IEnumerable<string> ecdhColumns = new List<string>()
+            {
+                "op",
+                "op/s"
+            };
             MatchCollection rsaPerformanceResults = Regex.Matches(this.RawText, $@"((?:\w *\(*)+(?:bits|\)))(\s*[0-9\.]+s)(\s*[0-9\.]+s)(\s*[0-9\.]+)(\s*[0-9\.]+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            // Example:
+            //                           op      op/s
+            // 448 bits ecdh(X448)   0.0000s  42896.0
+            if (rsaPerformanceResults?.Any() == false)
+            {
+                rsaPerformanceResults = Regex.Matches(this.RawText, $@"((?:\w *\(*)+(?:bits|\)))(\s*[0-9\.]+s)(\s*[0-9\.]+)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            }
+
             if (rsaPerformanceResults?.Any() == true)
             {
                 // return datatable with rsa name, column, value per row
@@ -302,8 +316,28 @@ namespace VirtualClient.Actions
                     new DataColumn(OpenSslMetricsParser.ColumnValue, typeof(double)),
                 });
 
+                // Match results for op, op/s
                 foreach (Match match in rsaPerformanceResults)
                 {
+                    if (match.Groups.Count == 4
+                       && match.Groups[2].Captures?.Any() == true)
+                    {
+                        int typeIndex = 0;
+                        string rsaAlgorithm = match.Groups[1].Value.Trim();
+                        for (int i = 2; i < 4; i++)
+                        {
+                            Match numericMatch = Regex.Match(match.Groups[i].Value, @"[-0-9\.]+", RegexOptions.IgnoreCase);
+                            if (numericMatch.Success)
+                            {
+                                parsedSuccessfully = true;
+                                double value = double.Parse(numericMatch.Value.Trim());
+                                rsaResults.Rows.Add(rsaAlgorithm, ecdhColumns.ElementAt(typeIndex), value);
+                            }
+
+                            typeIndex++;
+                        }
+                    } 
+
                     if (match.Groups.Count == 6
                         && match.Groups[2].Captures?.Any() == true)
                     {


### PR DESCRIPTION
 Extended OpenSSL Metrics Parser to fix invalid result format for three of the Scenarios of the ABC-OpenSSL profile.